### PR TITLE
Correct share url

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,6 +335,6 @@ window.viewShape = (key) => {
 
 window.shareShape = () => {
   const code = document.getElementById("code").value.trim();
-  const url = "https://view.shapez.io?" + code;
+  const url = "https://viewer.shapez.io?" + code;
   alert("You can share this url: " + url);
 };


### PR DESCRIPTION
The published URL is https://viewer.shapez.io/ -- view.shapez.io does not resolve