### PR TITLE
Reimplement layout with flexbox + mobile layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -6,16 +6,14 @@
 html,
 body {
     width: 100%;
-    height: 100%;
+    min-height: 100%;
     padding: 0;
-}
-body {
-    font-family: "Barlow", sans-serif;
-    background: #fff;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-content: center;
     justify-content: center;
+    font-family: "Barlow", sans-serif;
+    background: #fff;
 }
 
 h1, h2, h3 {
@@ -26,6 +24,7 @@ h1, h2, h3 {
 
 h1 {
     margin-bottom: 30px;
+    text-align: center;
 }
 
 code {
@@ -45,13 +44,16 @@ a{
     margin-bottom: 10px;
     background: #fff;
     padding: 40px;
+    text-align: center;
 }
 
 #resultWrapper #result {
+    max-width: 100%;
+    max-height: 100%;
 }
 
 #code {
-    width: 594px;
+    width: 100%;
     font-family: monospace;
     padding: 30px;
     box-sizing: border-box;
@@ -66,7 +68,7 @@ a{
 }
 
 #error {
-    height: 40px;
+    /* height: 40px; */
     color: #f77;
     margin-top: 10px;
     display: flex;
@@ -93,15 +95,26 @@ button:hover {
 }
 
 .grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-column-gap: 20px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: stretch;
+}
+
+.col {
+    margin: 10px;
+    max-width: 594px;
+    flex-grow: 1;
+    flex-basis: 0;
+}
+
+.grid.shapeCodes > .col {
+    margin: 0;
 }
 
 .infoBox {
     background: #eee;
     padding: 20px;
-    width: 500px;
 }
 .infoBox h3 {
     margin-top: 20px;
@@ -150,4 +163,21 @@ ul {
 }
 .footer {
     margin-top: 30px;
+    margin-bottom: 30px;
+    text-align: center;
+}
+
+@media screen and (max-width: 768px) {
+    .grid {
+        flex-direction: column;
+    }
+    .col {
+        box-sizing: border-box;
+        max-width: none;
+        width: 100%;
+        margin: 0;
+    }
+    #error {
+        padding: 0 10px;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <title>
       shapez.io shape generator
     </title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="index.css" media="all" />
     <script async src="index.js"></script>
     <link


### PR DESCRIPTION
I redid much of the CSS here to hopefully improve the usability of the tool:
* Fixed #8 for all situations I could find
* Introduced a decent mobile layout that spans the width of the screen (includes the only HTML change here)
* Shape preview is now scaled down when the screen isn't wide enough
* Replaced grids with flexboxes for a more even layout
* Spaced the footer further from the bottom a bit, so that is isn't chopped off awkwardly at the end of the page