### PR TITLE
Fix incorrect logo shape example

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
             ["----RuRu", "Half rectangle"],
             ["CgScScCg", "Circles and stars mixed"],
             ["RpRpRpRp:CwCwCwCw", "Layering example"],
-            ["CuRw--Rw:----Ru--", "Logo Shape"],
+            ["RuCw--Cw:----Ru--", "Logo Shape"],
           ];
           for (let i = 0; i < examples.length; ++i) {
             const [key, desc] = examples[i];

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
             ["----RuRu", "Half rectangle"],
             ["CgScScCg", "Circles and stars mixed"],
             ["RpRpRpRp:CwCwCwCw", "Layering example"],
-            ["CuRw--Rw:----Cu--", "Logo Shape"],
+            ["CuRw--Rw:----Ru--", "Logo Shape"],
           ];
           for (let i = 0; i < examples.length; ++i) {
             const [key, desc] = examples[i];


### PR DESCRIPTION
Logo shape in 'Examples' should have gray rectangle (not gray circle on top layer).